### PR TITLE
Added GPT-3.5-turbo support

### DIFF
--- a/app.py
+++ b/app.py
@@ -21,6 +21,28 @@ def index():
     result = request.args.get("result")
     return render_template("index.html", result=result)
 
+# run on model gpt-3.5-turbo 
+@app.route("/turbo", methods=("GET", "POST"))
+def turbo():
+    if request.method == "POST":
+        animal = request.form["animal"]
+        response = openai.ChatCompletion.create( #Needs OpenAI 0.27 above )
+            model="gpt-3.5-turbo",
+            messages=[
+                        {"role": "system", "content": "You are a expert in zoology"},
+                        {"role": "assistant", "content": "Suggest three names for an animal that is a superhero."},
+                        {"role": "user", "content": "Cat"},
+                        {"role": "assistant", "content": "Captain Sharpclaw, Agent Fluffball, The Incredible Feline"},
+                        {"role": "user", "content": "Dog"},
+                        {"role": "assistant", "content": "Ruff the Protector, Wonder Canine, Sir Barks-a-Lot"},
+                        {"role": "user", "content": animal},
+                    ]
+        )
+        return redirect(url_for("turbo", result=response['choices'][0]['message']['content']))
+
+    result = request.args.get("result")
+    return render_template("index-turbo.html", result=result)
+
 
 def generate_prompt(animal):
     return """Suggest three names for an animal that is a superhero.

--- a/templates/index-turbo.html
+++ b/templates/index-turbo.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<head>
+  <title>OpenAI Quickstart</title>
+  <link
+    rel="shortcut icon"
+    href="{{ url_for('static', filename='dog.png') }}"
+  />
+  <link rel="stylesheet" href="{{ url_for('static', filename='main.css') }}" />
+</head>
+
+<body>
+  <img src="{{ url_for('static', filename='dog.png') }}" class="icon" />
+  <h3>Name my pet</h3>
+  <form action="/turbo" method="post">
+    <input type="text" name="animal" placeholder="Enter an animal" required />
+    <input type="submit" value="Generate names" />
+  </form>
+  {% if result %}
+  <div class="result">{{ result }}</div>
+  {% endif %}
+</body>


### PR DESCRIPTION
Hi, I was explaining some AI new comers to understand how the new **GPT-3.5-turbo** works and gave this python tutorial to learn from. But then realised that the new model isn't supported by the tutorial yet. Hence added GPT-3.5-turbo support to it.

User can run a demo of new model on [http:/localhost:5000/turbo](http:/localhost:5000/turbo) with exactly the same behaviour as the earlier tutorial for text-davinci-003. Earlier one continue to be available as before at [http:/localhost:5000](http:/localhost:5000)

README.md will need an update too. Let me know if you want me to push an update for that as well.