### PR TITLE
Add a argument to ordering

### DIFF
--- a/examples/assistant-basic/assistant.py
+++ b/examples/assistant-basic/assistant.py
@@ -45,7 +45,10 @@ def run_assistant(thread_id, assistant_id):
 
 
 def get_newest_message(thread_id):
-    thread_messages = client.beta.threads.messages.list(thread_id)
+    thread_messages = client.beta.threads.messages.list(
+        thread_id=thread_id,
+        order="asc"
+    )
     return thread_messages.data[0]
 
 


### PR DESCRIPTION
While exploring code snippets of OpenAI Thread API, I've reached this code. 
In my amateur opinion, it seems forgot to add the ordering argument to ensure 'newest' message.